### PR TITLE
added settingsname and routingkey arguments

### DIFF
--- a/bin/handler-victorops.rb
+++ b/bin/handler-victorops.rb
@@ -55,7 +55,6 @@ class VictorOps < Sensu::Handler
     state_message = description
     begin
       timeout(10) do
-
         case @event['action']
         when 'create'
           case @event['check']['status']
@@ -68,7 +67,7 @@ class VictorOps < Sensu::Handler
           message_type = 'RECOVERY'
         end
 
-        payload = Hash.new
+        payload = {}
         payload[:message_type] = message_type
         payload[:state_message] = state_message.chomp
         payload[:entity_id] = entity_id


### PR DESCRIPTION
Added settingsname and routingkey arguments to allow for multiple routing keys and accounts

Or having default settings within the victorops.json settings for api_url and routing_key and override with a different routing key in the handler definition

Also added some checks if required values not set
